### PR TITLE
fix: amended downloadPermissions tests

### DIFF
--- a/src/test/java/org/dvsa/testing/framework/stepdefs/vol/InternalApplication.java
+++ b/src/test/java/org/dvsa/testing/framework/stepdefs/vol/InternalApplication.java
@@ -261,4 +261,12 @@ public class InternalApplication extends BasePage{
     public void theDocumentIsListedOnThePage() {
         assertTrue(isTextPresent("GV - Blank letter to operator"));
     }
+
+    @And("i save and email the letter")
+    public void iSaveAndEmailTheLetter() {
+        UniversalActions.clickSubmit();
+        waitForTextToBePresent("Send letter");
+        click("form-actions[email]",SelectorType.ID);
+        waitForTextToBePresent("The document has been saved and sent by email");
+    }
 }

--- a/src/test/resources/org/dvsa/testing/framework/features/SelfServe/Documents/download-permissions.feature
+++ b/src/test/resources/org/dvsa/testing/framework/features/SelfServe/Documents/download-permissions.feature
@@ -8,13 +8,14 @@ Background:
 
   Scenario: Operator is able to download the document
     And i generate a letter
+    And i save and email the letter
     And i note the document id
     And i log back in as the operator
     Then i should be able to download the file
 
   Scenario: Operator is prevented from downloading the document
-    And i change the operator correspondence to Post
     And i generate a letter
+    And i save the letter
     And i note the document id
     And i log back in as the operator
     Then i should not be able to download the file


### PR DESCRIPTION
amended downloadPermissions tests as VOL-5381 causing test to fail

<!--
Amended test so no longer generates licence documents as VOL-5381 specifically relaxes permissions re those documents
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
