### PR TITLE
fix: remove regression tag on vehicle search test

### DIFF
--- a/src/test/resources/org/dvsa/testing/framework/EBSR/EBSR.xml
+++ b/src/test/resources/org/dvsa/testing/framework/EBSR/EBSR.xml
@@ -4398,7 +4398,7 @@
             <OperatorShortName>Stagecoach</OperatorShortName>
             <OperatorNameOnLicence>Greater Manchester Buses South Ltd</OperatorNameOnLicence>
             <TradingName>Stagecoach Manchester</TradingName>
-            <LicenceNumber>PH2077403</LicenceNumber>
+            <LicenceNumber>PH2078518</LicenceNumber>
             <LicenceClassification>standardNational</LicenceClassification>
             <EnquiryTelephoneNumber>
                 <TelNationalNumber>0161 228 7811</TelNationalNumber>
@@ -4498,7 +4498,7 @@
                 </Line>
             </Lines>
             <OperatingPeriod>
-                <StartDate>2024-06-24</StartDate>
+                <StartDate>2024-04-21</StartDate>
             </OperatingPeriod>
             <OperatingProfile>
                 <RegularDayType>
@@ -10007,8 +10007,8 @@
             <SubmissionDate>2016-10-24</SubmissionDate>
             <VosaRegistrationNumber>
                 <TanCode>PC</TanCode>
-                <LicenceNumber>PH2077403</LicenceNumber>
-                <RegistrationNumber>360</RegistrationNumber>
+                <LicenceNumber>PH2078518</LicenceNumber>
+                <RegistrationNumber>359</RegistrationNumber>
             </VosaRegistrationNumber>
             <ApplicationClassification>new</ApplicationClassification>
             <VariationNumber>0</VariationNumber>


### PR DESCRIPTION
## Removing internal regression tag on vehicle search as is not currently fit for purpose. Have raised separate ticket VOL-5467 to fix the test so that it works irrespective of anon data

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
