### PR TITLE
fix: force `en_US` date format to fix `Sep` `Sept` change in Java 11

### DIFF
--- a/src/test/java/org/dvsa/testing/framework/Utils/Generic/GenericUtils.java
+++ b/src/test/java/org/dvsa/testing/framework/Utils/Generic/GenericUtils.java
@@ -238,7 +238,7 @@ public class GenericUtils extends BasePage {
     }
 
     public static String getCurrentDate(String datePattern) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(datePattern);
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern(datePattern, Locale.US);
         return LocalDate.now().format(formatter);
     }
 


### PR DESCRIPTION
## Description

In Java 11+ the date format for `MMM` in `en_GB` has changed from `Sep` to `Sept`. This however isn't the case in PHP, and the short month is always 3 characters. To workaround this, we can force the date formatter to use `en_US` for this comparison which will return the `Sep`.
