### PR TITLE
refactor: make timeout configurable via repo var, set default higher

### DIFF
--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -117,8 +117,9 @@ jobs:
       - name: Wait for Job Completion
         env:
           JOB_ID: ${{ steps.submit-job.outputs.job_id }}
+          TIME_OUT: ${{ vars.BATCH_TIMEOUT_MINUTES || 30 }}
         run: |
-          TIME_OUT=15
+          TIME_OUT=${{ env.TIME_OUT }}
           JOB_ID=${{ env.JOB_ID }}
           count=0
           trap 'aws batch terminate-job --job-id $JOB_ID --reason "GitHub workflow cancelled"; exit 1' SIGINT SIGTERM


### PR DESCRIPTION
## Description

Smoke batch taking longer than 15min timeout. This makes that a param with a higher default if its not set.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
