### PR TITLE
chore: map "int" to "qa" before nonprod environments are renamed

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -53,6 +53,11 @@ check_environment_variables() {
 
 check_environment_variables || exit 1
 
+# Check if platformEnv is "int" and replace with "qa"
+if [ "${platformEnv}" = "int" ]; then
+    echo "Replacing platformEnv 'int' with 'qa'"
+    platformEnv="qa"
+fi
 
 # Echo the command to be captured in logs
 echo "Now running [ mvn --batch-mode clean verify $mavenOptions -U -Dwdm.proxy=${proxyHost}:${proxyPort} -Dhttps.proxyHost=${proxyHost} -Dhttps.proxyPort=${proxyPort} -Dhttp.proxyHost=${proxyHost} -Dhttp.proxyPort=${proxyPort} -Dhttp.nonProxyHosts=${noProxyJava} -Denv=${platformEnv} -Dbrowser=${browserName} -DbrowserVersion=${browserVersion} -Dplatform=${platform} -DgridURL=_hidden_ -Dtag.name=\"(not ${exclude_tags})\" -Dcucumber.filter.tags=${cucumberTags} ] .."


### PR DESCRIPTION
## Description

remap value in shell script so selenium tests operate on the QA environment before its renamed to "int" in time.

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?