### PR TITLE
chore: namespace allure results with env name to avoid dupe errors

### DIFF
--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -214,7 +214,7 @@ jobs:
       - name: Store Allure Results
         uses: actions/upload-artifact@v4
         with:
-          name: allure-results
+          name: allure-results-${{ inputs.platform_env }}
           path: ./upload/${{ env.FOLDER_NAME }}/allure-results
 
 
@@ -233,7 +233,7 @@ jobs:
       - name: Download Allure Report
         uses: actions/download-artifact@v4
         with:
-          name: allure-results
+          name: allure-results-${{ inputs.platform_env }}
 
       - name: Console Output Report
         run: |


### PR DESCRIPTION
Release-As: 3.8.2

## Description

append env name to allure-results artefacts as test workflow to avoid dupe errors when e2etest is called several times from a parent workflow.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [x] Have you have added tests that prove the fix or feature is effective and working
- [x] Did you make sure to update any documentation relating to this change?
