### PR TITLE
fix: prevent duplicate report name on subsequent attempts of workflow

### DIFF
--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -53,7 +53,7 @@ permissions:
   checks: write
 
 env:
-  REPORT_NAME: "allure.zip"
+  REPORT_NAME: "allure_attempt_${{ github.run_number }}.zip"
   ROLE_ARN: ${{ inputs.aws_role }}
   BUCKET_NAME: ${{ inputs.bucket_name }}
   BUCKET_KEY: ${{ inputs.bucket_key }}


### PR DESCRIPTION
## Description

The current workflow has a fixed report name that is only in a unique directory in S3 per Github runID. Consequently when you try and re-run failed stages for a workflow the upload to S3 fails as the allure report zip name is not unique. There are a couple of situations where we have had to do this as part of the vol-app pipeline due to issues we have experienced.

By adding the attempt to the filename this should prevent this happening while also ensuring you can keep subsequent reports. You could remove this and simply overwrite each time but i wasn't sure how much value there was in older reports so opted to keep them as an alternative.

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
