### PR TITLE
fix: build on same arch as prod

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -30,7 +30,7 @@ env:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
 
@@ -40,8 +40,8 @@ jobs:
 
   build:
     name: Build ${{ inputs.push && 'and push' || '' }}
-    runs-on: ubuntu-latest
-    steps:
+    runs-on: ubuntu-24.04-arm
+    steps: 
       - uses: actions/checkout@v4
 
       - uses: whelk-io/maven-settings-xml-action@v22


### PR DESCRIPTION
## Description

Build docker container on same arch to avoid qemu errors

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
