### PR TITLE
fix: proxy settings not needed when installing deps on GH Runner

### DIFF
--- a/infra/docker/batch/Dockerfile
+++ b/infra/docker/batch/Dockerfile
@@ -1,11 +1,10 @@
 FROM maven:3.9.6-amazoncorretto-17 as maven
 ENV platform="LINUX"
 ENV gridURL="https://selenium-hub.olcs.dev-dvsacloud.uk/"
-ENV proxyHost=$proxyHost
-ENV proxyPort=$proxyPort
+
 WORKDIR /app
 
-# Install system dependencies and AWS CLI in a single layer
+# Install system dependencies
 RUN yum update -y && \
     yum install -y zip-3.* unzip-6.* && \
     yum clean all && \
@@ -21,11 +20,13 @@ COPY ./settings.xml /root/.m2/settings.xml
 # Copy pom files for dependency resolution
 COPY ./pom.xml ./
 
-# Download all dependencies and prepare the app in a single layer
-RUN mvn dependency:go-offline -B && \
-    chmod +x ./run.sh
+# Try to download dependencies using the settings.xml credentials
+RUN mvn dependency:go-offline -B || echo "Dependency download failed, will download at runtime"
 
-# Now copy the rest of the application
+# Copy the rest of the application
 COPY . .
+
+# Make run.sh executable
+RUN chmod +x ./run.sh
 
 CMD ["/bin/sh", "-c", "./run.sh"]


### PR DESCRIPTION
## Description

No proxy env vars needed during dep install on gh runner

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
