### PR TITLE
fix: generate build-time settings.xml with no proxy and runtime with proxy baked in

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -77,15 +77,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: whelk-io/maven-settings-xml-action@v22
-        name: generate settings xml
+        name: generate runtime settings xml
         with:
           servers: ${{ needs.prepare.outputs.push == 'true' && env.BATCH_SETTINGS || env.RUNNER_SETTINGS }}
           proxies: '[{ "id":"dvsa-ci-proxy", "active": "true", "protocol": "http", "host": "${{vars.CI_PROXY}}", "port": "${{vars.CI_PROXYPORT}}" }]'
           repositories: '[ { "id":"dvsa-github-packages", "name":"dvsa-github-packages", "url":"https://maven.pkg.github.com/dvsa/*", "releases": { "enabled": "true" }, "snapshots": { "enabled": "true" } }]'
-          output_file: ./settings.xml
+          output_file: ./settings-runtime.xml
 
-      - name: view settings.xml
-        run: cat ./settings.xml
+      - uses: whelk-io/maven-settings-xml-action@v22
+        name: generate build-time settings xml
+        with:
+          servers: ${{ needs.prepare.outputs.push == 'true' && env.BATCH_SETTINGS || env.RUNNER_SETTINGS }}
+          repositories: '[ { "id":"dvsa-github-packages", "name":"dvsa-github-packages", "url":"https://maven.pkg.github.com/dvsa/*", "releases": { "enabled": "true" }, "snapshots": { "enabled": "true" } }]'
+          output_file: ./settings-build.xml
+
+      - name: view settings files
+        run: |
+          echo "Build-time settings:"
+          cat ./settings-build.xml
+          echo "Runtime settings:"
+          cat ./settings-runtime.xml
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/infra/docker/batch/Dockerfile
+++ b/infra/docker/batch/Dockerfile
@@ -4,7 +4,7 @@ ENV gridURL="https://selenium-hub.olcs.dev-dvsacloud.uk/"
 
 WORKDIR /app
 
-# Install system dependencies
+# Install system dependencies and AWS CLI
 RUN yum update -y && \
     yum install -y zip-3.* unzip-6.* && \
     yum clean all && \
@@ -14,14 +14,17 @@ RUN yum update -y && \
     ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
     rm -f awscliv2.zip
 
-# Copy Maven settings
-COPY ./settings.xml /root/.m2/settings.xml
+# Copy build-time Maven settings (without proxy)
+COPY ./settings-build.xml /root/.m2/settings.xml
 
 # Copy pom files for dependency resolution
 COPY ./pom.xml ./
 
-# Try to download dependencies using the settings.xml credentials
+# Download dependencies (should work without proxy)
 RUN mvn dependency:go-offline -B || echo "Dependency download failed, will download at runtime"
+
+# Now copy the runtime settings file (with proxy) for later use
+COPY ./settings-runtime.xml /root/.m2/settings.xml
 
 # Copy the rest of the application
 COPY . .


### PR DESCRIPTION
## Description

Generate a buildtime and runtime settings.xml to avoid proxy issued installing deps from GH runner

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
