### PR TITLE
fix: bump INT regression timeout to 90mins for iuweb/ssweb

### DIFF
--- a/.github/workflows/e2eInternalRegression.yaml
+++ b/.github/workflows/e2eInternalRegression.yaml
@@ -31,7 +31,7 @@ on:
         type: number
         required: false
         description: "Timeout in minutes for the AWS Batch job"
-        default: 60
+        default: 90
 
 jobs:
   call-e2etest:

--- a/.github/workflows/e2eSelfServeRegression.yaml
+++ b/.github/workflows/e2eSelfServeRegression.yaml
@@ -31,7 +31,7 @@ on:
         type: number
         required: false
         description: "Timeout in minutes for the AWS Batch job"
-        default: 60
+        default: 90
 
 jobs:
   call-e2etest:


### PR DESCRIPTION
## Description

move to 90min timeout for ssweb and iuweb regressions in case any test re-tries push beyond 60min

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [x] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
