### PR TITLE
fix:update GitHub Actions to v5 to support Node.js 24

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       vft: ${{ steps.vft-version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -66,7 +66,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: ${{ env.WORKING_DIR }}/Dockerfile
@@ -76,7 +76,7 @@ jobs:
     name: Build ${{ needs.prepare.outputs.push == 'true' && 'and push' || '' }}
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: whelk-io/maven-settings-xml-action@v22
         name: generate runtime settings xml
         with:
@@ -116,7 +116,7 @@ jobs:
 
       - name: Configure AWS credentials
         if: ${{ needs.prepare.outputs.push == 'true' }}
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ vars.ACCOUNT_NONPROD_TEST_OIDC_ROLE }}
           aws-region: ${{ vars.TF_AWS_REGION}}

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -86,17 +86,17 @@ jobs:
       JOB_NAME: ${{ needs.create-job-name.outputs.job_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS with provided credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ env.ROLE_ARN }}
           aws-region: ${{ vars.DVSA_AWS_REGION }}
           role-duration-seconds: 8400
 
       - name: Cache local Maven repository
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -207,10 +207,10 @@ jobs:
       FOLDER_NAME: ${{ needs.create-job-name.outputs.job_name }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Configure AWS with provided credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           role-to-assume: ${{ env.ROLE_ARN }}
           aws-region: ${{ vars.DVSA_AWS_REGION }}
@@ -237,7 +237,7 @@ jobs:
         run: echo "timestamp=$(date +%Y%m%d%H%M%S%3N)" >> $GITHUB_ENV
 
       - name: Store Allure Results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: e2e-${{ needs.create-job-name.outputs.job_name }}
           path: ./upload/${{ env.FOLDER_NAME }}/allure-results
@@ -252,10 +252,10 @@ jobs:
     environment: ${{ inputs.platform_env }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download Allure Report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: e2e-${{ needs.create-job-name.outputs.job_name }}
 

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -17,7 +17,7 @@ jobs:
       name: build
       runs-on: ubuntu-latest
       steps:
-       - uses: actions/checkout@v4
+       - uses: actions/checkout@v5
        
        - name: Set up Java 21
          uses: actions/setup-java@v4

--- a/.github/workflows/report.yaml
+++ b/.github/workflows/report.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       
       - name: Download Allure Report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: allure-results
           

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -26,7 +26,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
   
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v5
         - uses: snyk/actions/setup@master
         - uses: actions/setup-java@v4
           with:


### PR DESCRIPTION
- actions/checkout@v4 → actions/checkout@v5
- actions/cache@v4 → actions/cache@v5
- actions/upload-artifact@v4 → actions/upload-artifact@v5
- actions/download-artifact@v4 → actions/download-artifact@v5
- aws-actions/configure-aws-credentials@v4 → aws-actions/configure-aws-credentials@v5

This resolves Node.js 20 deprecation warnings and ensures compatibility with the upcoming Node.js 24 default on GitHub Actions runners.

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
