### PR TITLE
fix: replace legacy accessibility-library with AI framework and add r…

### DIFF
--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -268,7 +268,7 @@ jobs:
         run: |
           ACCESSIBILITY_URL="https://${{ env.BUCKET_NAME }}.s3.amazonaws.com/${{ env.BUCKET_KEY }}/${{ env.REPORT_KEY }}/reports/accessibility-report.html"
           echo "Accessibility report is available at ${ACCESSIBILITY_URL}"
-          echo "### :wheelchair: Accessibility Report" >> $GITHUB_STEP_SUMMARY
+          echo "### Accessibility Report" >> $GITHUB_STEP_SUMMARY
           echo "[View Accessibility Report](${ACCESSIBILITY_URL})" >> $GITHUB_STEP_SUMMARY
 
       - name: Get Summary

--- a/.github/workflows/e2etest.yaml
+++ b/.github/workflows/e2etest.yaml
@@ -263,6 +263,14 @@ jobs:
         run: |
           echo "Allure report is available at s3://${{ env.BUCKET_NAME }}/${{ env.BUCKET_KEY }}/${{env.REPORT_KEY}}/site/allure-maven-plugin/index.html"
 
+      - name: Link Accessibility Report
+        if: contains(inputs.cucumber_tags, '@accessibility')
+        run: |
+          ACCESSIBILITY_URL="https://${{ env.BUCKET_NAME }}.s3.amazonaws.com/${{ env.BUCKET_KEY }}/${{ env.REPORT_KEY }}/reports/accessibility-report.html"
+          echo "Accessibility report is available at ${ACCESSIBILITY_URL}"
+          echo "### :wheelchair: Accessibility Report" >> $GITHUB_STEP_SUMMARY
+          echo "[View Accessibility Report](${ACCESSIBILITY_URL})" >> $GITHUB_STEP_SUMMARY
+
       - name: Get Summary
         id: get-summary
         uses: dvsa/.github/.github/actions/surefire-report-summary@v5.0.8

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <!-- DVSA Internal Libraries -->
         <active-support.version>2.15.4</active-support.version>
         <api-calls.version>3.3.2</api-calls.version>
-        <axe-scanner.version>2.11.4</axe-scanner.version>
+        <accessibility-ai.version>2.0.0</accessibility-ai.version>
 
         <!-- Testing Framework - Cucumber & JUnit -->
         <cucumber.version>7.20.1</cucumber.version>
@@ -145,9 +145,9 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.dvsa.testing.lib</groupId>
-            <artifactId>accessibility-library</artifactId>
-            <version>${axe-scanner.version}</version>
+            <groupId>org.dvsa.testing.framework</groupId>
+            <artifactId>accessibility-ai-core</artifactId>
+            <version>${accessibility-ai.version}</version>
         </dependency>
         <dependency>
             <groupId>org.dvsa.testing.framework</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <!-- DVSA Internal Libraries -->
         <active-support.version>2.15.4</active-support.version>
         <api-calls.version>3.3.2</api-calls.version>
-        <accessibility-ai.version>2.0.0</accessibility-ai.version>
+        <accessibility-ai.version>2.0.1</accessibility-ai.version>
 
         <!-- Testing Framework - Cucumber & JUnit -->
         <cucumber.version>7.20.1</cucumber.version>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <!-- DVSA Internal Libraries -->
         <active-support.version>2.15.4</active-support.version>
         <api-calls.version>3.3.2</api-calls.version>
-        <accessibility-ai.version>2.0.1</accessibility-ai.version>
+        <accessibility-ai.version>2.0.2</accessibility-ai.version>
 
         <!-- Testing Framework - Cucumber & JUnit -->
         <cucumber.version>7.20.1</cucumber.version>

--- a/run.sh
+++ b/run.sh
@@ -75,6 +75,15 @@ if [ $? -eq 0 ]; then
   zip -qr ./allure_attempt_${resultsBuildNumber}.zip target
   cd target
   aws s3 cp site s3://${resultsTargetBucket}/${resultsTargetBucketPath}/${buildId}/site/ --recursive
+  # Upload accessibility report and screenshots to S3 for CI linking
+  if [ -d "reports" ]; then
+    # Copy timestamped report to a fixed name for predictable CI linking
+    ACCESSIBILITY_REPORT=$(find reports -maxdepth 1 -name "*-accessibility.html" | head -1)
+    if [ -n "$ACCESSIBILITY_REPORT" ]; then
+      cp "$ACCESSIBILITY_REPORT" reports/accessibility-report.html
+    fi
+    aws s3 cp reports s3://${resultsTargetBucket}/${resultsTargetBucketPath}/${buildId}/reports/ --recursive
+  fi
   aws s3 cp ../allure_attempt_${resultsBuildNumber}.zip s3://${resultsTargetBucket}/${resultsTargetBucketPath}/${buildId}/
 else
   echo "Maven command failed!"

--- a/src/test/java/org/dvsa/testing/framework/Journeys/licence/BusRegistrationJourney.java
+++ b/src/test/java/org/dvsa/testing/framework/Journeys/licence/BusRegistrationJourney.java
@@ -24,7 +24,6 @@ import org.openqa.selenium.*;
 import org.openqa.selenium.remote.LocalFileDetector;
 import org.openqa.selenium.remote.RemoteWebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
-import scanner.AXEScanner;
 
 import java.io.IOException;
 import java.time.Duration;

--- a/src/test/java/org/dvsa/testing/framework/Journeys/licence/BusinessDetailsJourney.java
+++ b/src/test/java/org/dvsa/testing/framework/Journeys/licence/BusinessDetailsJourney.java
@@ -6,8 +6,7 @@ import activesupport.faker.FakerUtils;
 import org.dvsa.testing.framework.Utils.Generic.UniversalActions;
 import org.dvsa.testing.framework.pageObjects.BasePage;
 import org.dvsa.testing.framework.pageObjects.enums.SelectorType;
-import org.dvsa.testing.framework.stepdefs.vol.AccessibilitySteps;
-import scanner.AXEScanner;
+import org.dvsa.testing.framework.axe.AXEScanner;
 
 import java.io.IOException;
 import java.util.Objects;
@@ -36,8 +35,7 @@ public class BusinessDetailsJourney extends BasePage {
         UniversalActions.clickSaveAndContinue();
         enterCorrespondenceAddress();
         UniversalActions.clickSaveAndContinue();
-        AXEScanner axeScanner = AccessibilitySteps.scanner;
-        axeScanner.scan(true);
+        AXEScanner.scan(activesupport.driver.Browser.navigate());
     }
 
     public void enterCorrespondenceAddress() {

--- a/src/test/java/org/dvsa/testing/framework/Journeys/licence/DirectorJourney.java
+++ b/src/test/java/org/dvsa/testing/framework/Journeys/licence/DirectorJourney.java
@@ -7,10 +7,9 @@ import activesupport.string.Str;
 import org.dvsa.testing.framework.Utils.Generic.UniversalActions;
 import org.dvsa.testing.framework.pageObjects.BasePage;
 import org.dvsa.testing.framework.pageObjects.enums.SelectorType;
-import org.dvsa.testing.framework.stepdefs.vol.AccessibilitySteps;
+import org.dvsa.testing.framework.axe.AXEScanner;
 import org.hamcrest.MatcherAssert;
 import org.openqa.selenium.WebElement;
-import scanner.AXEScanner;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -86,8 +85,7 @@ public class DirectorJourney extends BasePage {
         if (isTitlePresent(convictionsAndPenaltiesTitle, 5)) {
             completeConvictionsAndPenalties("N");
         }
-            AXEScanner axeScanner = AccessibilitySteps.scanner;
-            axeScanner.scan(true);
+            AXEScanner.scan(activesupport.driver.Browser.navigate());
         }
 
 

--- a/src/test/java/org/dvsa/testing/framework/Journeys/licence/SurrenderJourney.java
+++ b/src/test/java/org/dvsa/testing/framework/Journeys/licence/SurrenderJourney.java
@@ -9,8 +9,6 @@ import org.dvsa.testing.framework.Utils.Generic.UniversalActions;
 import org.dvsa.testing.framework.enums.SelfServeSection;
 import org.dvsa.testing.framework.pageObjects.BasePage;
 import org.dvsa.testing.framework.pageObjects.enums.SelectorType;
-import org.dvsa.testing.framework.stepdefs.vol.AccessibilitySteps;
-import scanner.AXEScanner;
 
 import java.io.IOException;
 import java.util.Objects;

--- a/src/test/java/org/dvsa/testing/framework/stepdefs/vol/AccessibilitySteps.java
+++ b/src/test/java/org/dvsa/testing/framework/stepdefs/vol/AccessibilitySteps.java
@@ -4,15 +4,22 @@ import activesupport.IllegalBrowserException;
 import activesupport.driver.Browser;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import io.qameta.allure.Allure;
 import io.qameta.allure.Step;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.dvsa.testing.framework.Injectors.World;
+import org.dvsa.testing.framework.axe.AXEScanner;
+import org.dvsa.testing.framework.axe.AXEScanner.ViolationEntry;
+import org.dvsa.testing.framework.jsoup.SpiderCrawler;
 import org.dvsa.testing.framework.pageObjects.BasePage;
 import org.dvsa.testing.framework.pageObjects.enums.SelectorType;
+import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.support.Color;
-import scanner.AXEScanner;
-import scanner.AXEScanner.ScanResult;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -22,7 +29,7 @@ public class AccessibilitySteps extends BasePage {
     private static final Logger LOGGER = LogManager.getLogger(AccessibilitySteps.class);
     private final World world;
 
-    public static final AXEScanner scanner = new AXEScanner();
+    private List<ViolationEntry> scenarioViolations = new ArrayList<>();
 
     public AccessibilitySteps(World world) {
         this.world = world;
@@ -64,29 +71,59 @@ public class AccessibilitySteps extends BasePage {
     public void iScanForAccessibilityViolations() throws IllegalBrowserException {
         String currentUrl = Browser.navigate().getCurrentUrl();
         LOGGER.info("Scanning page for accessibility violations: {}", currentUrl);
-        ScanResult result = scanner.scan(true);
-        LOGGER.info("Scan complete - Violations: {}, Incomplete: {}",
-                result.getViolationCount(), result.getIncompleteCount());
+
+        int beforeSize = AXEScanner.getAllViolations().size();
+        WebDriver driver = Browser.navigate();
+        AXEScanner.scan(driver);
+
+        LOGGER.info("Starting spider crawl from: {}", currentUrl);
+        SpiderCrawler.crawler(1, currentUrl, new HashSet<>(), driver);
+
+        int afterSize = AXEScanner.getAllViolations().size();
+        int newViolations = afterSize - beforeSize;
+        if (newViolations > 0) {
+            List<ViolationEntry> allViols = AXEScanner.getAllViolations();
+            scenarioViolations.addAll(allViols.subList(beforeSize, afterSize));
+        }
+
+        LOGGER.info("Scan + crawl complete - New violations found: {}", newViolations);
     }
 
 
     @Then("no issues should be present on the page")
     @Step("Verify no accessibility issues")
     public void noIssuesShouldBePresentOnThePage() {
-        scanner.logViolations();
-        scanner.attachToAllure();
-        int totalViolations = scanner.getTotalViolationsCount();
-        int criticalViolations = scanner.getCriticalViolationsCount();
+        int totalViolations = scenarioViolations.size();
+        long criticalViolations = scenarioViolations.stream()
+                .filter(v -> "critical".equalsIgnoreCase(v.rule().getImpact()))
+                .count();
+
+        if (totalViolations > 0) {
+            StringBuilder summary = new StringBuilder();
+            for (ViolationEntry entry : scenarioViolations) {
+                summary.append(String.format("  [%s] %s - %s on %s%n",
+                        entry.rule().getImpact(),
+                        entry.rule().getId(),
+                        entry.rule().getDescription(),
+                        entry.pageUrl()));
+            }
+            Allure.addAttachment("Accessibility Violations", "text/plain", summary.toString());
+        }
+
         if (totalViolations == 0) {
             LOGGER.info("✓ No accessibility violations found");
         } else if (criticalViolations == 0) {
-            LOGGER.warn(":warning: Found {} accessibility violation(s) but none are CRITICAL - Test PASSES",
+            LOGGER.warn("Found {} accessibility violation(s) but none are CRITICAL - Test PASSES",
                     totalViolations);
         } else {
             LOGGER.error("✗ Found {} CRITICAL accessibility violation(s) - Test FAILS", criticalViolations);
-            String violationDetails = scanner.getViolationSummary();
+            String violationDetails = scenarioViolations.stream()
+                    .filter(v -> "critical".equalsIgnoreCase(v.rule().getImpact()))
+                    .map(v -> String.format("[%s] %s: %s", v.rule().getImpact(), v.rule().getId(), v.rule().getDescription()))
+                    .reduce("", (a, b) -> a + "\n" + b);
             fail(String.format("Found %d CRITICAL violation(s):\n%s", criticalViolations, violationDetails));
         }
+
+        scenarioViolations.clear();
     }
 }
-

--- a/src/test/java/org/dvsa/testing/framework/stepdefs/vol/EBSRUpload.java
+++ b/src/test/java/org/dvsa/testing/framework/stepdefs/vol/EBSRUpload.java
@@ -12,7 +12,6 @@ import org.openqa.selenium.NotFoundException;
 import org.openqa.selenium.TimeoutException;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.ui.WebDriverWait;
-import scanner.AXEScanner;
 
 import java.io.IOException;
 import java.time.Duration;

--- a/src/test/java/org/dvsa/testing/framework/stepdefs/vol/SubmitSelfServeApplication.java
+++ b/src/test/java/org/dvsa/testing/framework/stepdefs/vol/SubmitSelfServeApplication.java
@@ -6,7 +6,6 @@ import org.dvsa.testing.framework.Injectors.World;
 import io.cucumber.java.en.And;
 import org.dvsa.testing.framework.pageObjects.BasePage;
 import org.dvsa.testing.framework.pageObjects.enums.SelectorType;
-import scanner.AXEScanner;
 
 import java.io.IOException;
 

--- a/src/test/java/org/dvsa/testing/framework/stepdefs/vol/TestRunConfiguration.java
+++ b/src/test/java/org/dvsa/testing/framework/stepdefs/vol/TestRunConfiguration.java
@@ -7,6 +7,7 @@ import io.cucumber.java.Before;
 import io.cucumber.java.Scenario;
 import io.qameta.allure.Allure;
 import org.dvsa.testing.framework.Report.Config.Environments;
+import org.dvsa.testing.framework.axe.AXEScanner;
 import org.dvsa.testing.framework.pageObjects.enums.SelectorType;
 import org.openqa.selenium.OutputType;
 import org.openqa.selenium.TakesScreenshot;
@@ -57,4 +58,12 @@ public class TestRunConfiguration {
              Allure.addAttachment("Current URL", currentUrl);
         }
         }
+
+    @AfterAll
+    public static void generateAccessibilityReport() {
+        if (!AXEScanner.getAllViolations().isEmpty()) {
+            System.out.println("All scenarios complete. Generating AI-augmented accessibility report...");
+            AXEScanner.generateFinalReport();
+        }
+    }
     }


### PR DESCRIPTION
…eport linking

- Replace accessibility-library:2.11.4 with accessibility-ai-core:2.0.0
- Rewrite AccessibilitySteps to use AXEScanner static API + SpiderCrawler
- Add @AfterAll hook for final report generation
- Upload accessibility report to S3 alongside Allure in run.sh
- Add accessibility report link to GitHub job summary (gated on @accessibility tag)
- Remove unused scanner imports from journey files

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
