### PR TITLE
fix: replace deprecated trafficAreaList() with TrafficArea.values()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
         <!-- DVSA Internal Libraries -->
         <active-support.version>2.15.4</active-support.version>
-        <api-calls.version>3.3.2</api-calls.version>
+        <api-calls.version>4.1.0</api-calls.version>
         <accessibility-ai.version>2.0.2</accessibility-ai.version>
 
         <!-- Testing Framework - Cucumber & JUnit -->

--- a/src/test/java/org/dvsa/testing/framework/stepdefs/vol/FinancialEvidence.java
+++ b/src/test/java/org/dvsa/testing/framework/stepdefs/vol/FinancialEvidence.java
@@ -20,7 +20,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import static apiCalls.enums.TrafficArea.trafficAreaList;
+import static apiCalls.enums.TrafficArea.values;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class FinancialEvidence extends BasePage {
@@ -42,7 +42,7 @@ public class FinancialEvidence extends BasePage {
     public void iHaveALicenceWithAHgvAuthorisationOfAndInTrafficArea(String operatorType, String licenceType, String hgvAuthority, String trafficArea) throws HttpException {
         world.createApplication.setTotalOperatingCentreHgvAuthority(Integer.parseInt(hgvAuthority.replaceAll(" ", "")));
         world.createApplication.setNoOfAddedHgvVehicles(Integer.parseInt(hgvAuthority.replaceAll(" ", "")));
-        TrafficArea ta = trafficAreaList()[Integer.parseInt(trafficArea.replaceAll(" ", ""))];
+        TrafficArea ta = values()[Integer.parseInt(trafficArea.replaceAll(" ", ""))];
         world.licenceCreation.createLicenceWithTrafficArea(operatorType, licenceType, ta);
         this.licences.put(world.createApplication.getLicenceId(), new String[] {operatorType, licenceType, null, hgvAuthority, "0", null, null});
     }
@@ -51,7 +51,7 @@ public class FinancialEvidence extends BasePage {
     public void iHaveALicenceWithAHgvAuthorisationOfLgvAuthorisationOfAndInTrafficArea(String operatorType, String licenceType, String hgvAuthority, String lgvAuthority, String trafficArea) throws HttpException {
         world.createApplication.setTotalOperatingCentreHgvAuthority(Integer.parseInt(hgvAuthority.replaceAll(" ", "")));
         world.createApplication.setTotalOperatingCentreLgvAuthority(Integer.parseInt(lgvAuthority.replaceAll(" ", "")));
-        TrafficArea ta = trafficAreaList()[Integer.parseInt(trafficArea.replaceAll(" ", ""))];
+        TrafficArea ta = values()[Integer.parseInt(trafficArea.replaceAll(" ", ""))];
         world.licenceCreation.createLicenceWithTrafficArea(operatorType, licenceType, ta);
         this.licences.put(world.createApplication.getLicenceId(), new String[] {operatorType, licenceType, null, hgvAuthority, lgvAuthority, null, null});
     }
@@ -59,14 +59,14 @@ public class FinancialEvidence extends BasePage {
     @Given("i have a {string} {string} licence with a hgv authorisation of {string} in the North West Of England")
     public void iHaveALicenceWithAHgvAuthorisationOfAndInTrafficArea(String operatorType, String licenceType, String hgvAuthority) throws HttpException {
         world.createApplication.setTotalOperatingCentreHgvAuthority(Integer.parseInt(hgvAuthority.replaceAll(" ", "")));
-        TrafficArea ta = trafficAreaList()[1];
+        TrafficArea ta = values()[1];
         world.licenceCreation.createLicenceWithTrafficArea(operatorType, licenceType, ta);
         this.licences.put(world.createApplication.getLicenceId(), new String[] {operatorType, licenceType, null, hgvAuthority, "0", null, null});
     }
 
     @And("I have a valid {string} lgv only licence in traffic area {string}")
     public void iHaveAValidLgvOnlyLicenceFinancialEvidence(String NIFlag, String trafficArea) throws HttpException {
-        TrafficArea ta = trafficAreaList()[Integer.parseInt(trafficArea.replaceAll(" ", ""))];
+        TrafficArea ta = values()[Integer.parseInt(trafficArea.replaceAll(" ", ""))];
         world.licenceCreation.createLGVOnlyLicenceWithTrafficArea(NIFlag, ta);
         this.licences.put(world.createApplication.getLicenceId(), new String[] {"goods", "standard_international", "lgv" , null, String.valueOf(world.createApplication.getTotalOperatingCentreLgvAuthority()), null, null});
     }

--- a/src/test/java/org/dvsa/testing/framework/stepdefs/vol/ManageApplications.java
+++ b/src/test/java/org/dvsa/testing/framework/stepdefs/vol/ManageApplications.java
@@ -26,7 +26,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 
-import static apiCalls.enums.TrafficArea.trafficAreaList;
+import static apiCalls.enums.TrafficArea.values;
 import static org.dvsa.testing.framework.Utils.Generic.UniversalActions.refreshPageWithJavascript;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -104,7 +104,7 @@ public class ManageApplications extends BasePage {
         try {
             world.APIJourney.registerAndGetUserDetails(UserType.EXTERNAL.asString());
             world.createApplication.setNoOfAddedHgvVehicles(3);
-            for (TrafficArea ta : trafficAreaList()) {
+            for (TrafficArea ta : values()) {
                 world.licenceCreation.createApplicationWithTrafficArea(operatorType, licenceType, ta);
                 password = S3.getTempPassword(world.createApplication.getTransportManagerEmailAddress());
                 world.genericUtils.writeToFile(world.createApplication.getTransportManagerUserName(), password, fileName.concat("TM.csv"));
@@ -134,7 +134,7 @@ public class ManageApplications extends BasePage {
             }
             world.APIJourney.registerAndGetUserDetails(UserType.EXTERNAL.asString());
             for (int i = 0; i < Integer.parseInt(noOfLicences); i++) {
-                world.licenceCreation.createLicenceWithTrafficArea(operatorType, licenceType, trafficAreaList()[i]);
+                world.licenceCreation.createLicenceWithTrafficArea(operatorType, licenceType, values()[i]);
             }
         } finally {
             writeLock.unlock();
@@ -147,7 +147,7 @@ public class ManageApplications extends BasePage {
         try {
             world.APIJourney.registerAndGetUserDetails(UserType.EXTERNAL.asString());
             world.createApplication.setNoOfAddedHgvVehicles(3);
-            for (TrafficArea ta : trafficAreaList()) {
+            for (TrafficArea ta : values()) {
                 world.licenceCreation.createApplicationWithTrafficArea(operatorType, licenceType, ta);
             }
         } finally {
@@ -223,7 +223,7 @@ public class ManageApplications extends BasePage {
             world.createApplication.setTotalOperatingCentreHgvAuthority(Integer.parseInt(vehicleAuth));
             world.createApplication.setNoOfOperatingCentreVehicleAuthorised(Integer.parseInt(vehicleAuth));
             for (int i = 0; i < Integer.parseInt(noOfLicences); i++) {
-                world.licenceCreation.createLicenceWithTrafficArea(operatorType, licenceType, trafficAreaList()[i]);
+                world.licenceCreation.createLicenceWithTrafficArea(operatorType, licenceType, values()[i]);
             }
         } finally {
             writeLock.unlock();
@@ -272,7 +272,7 @@ public class ManageApplications extends BasePage {
         world.createApplication.setTotalOperatingCentreLgvAuthority(Integer.parseInt(lgvs));
 
         for (int i = 0; i < Integer.parseInt(noOfLicences); i++) {
-            TrafficArea ta = trafficAreaList()[i];
+            TrafficArea ta = values()[i];
             world.licenceCreation.createLicenceWithTrafficArea(operatorType, licenceType, ta);
         }
     }
@@ -463,7 +463,7 @@ public class ManageApplications extends BasePage {
             world.createApplication.setTotalOperatingCentreHgvAuthority(Integer.parseInt(vehicleAuth));
             world.createApplication.setNoOfOperatingCentreVehicleAuthorised(Integer.parseInt(vehicleAuth));
             for (int i = 0; i < Integer.parseInt(noOfLicences); i++) {
-                world.licenceCreation.createLicenceWithTrafficArea(operatorType, licenceType, trafficAreaList()[i]);
+                world.licenceCreation.createLicenceWithTrafficArea(operatorType, licenceType, values()[i]);
             }
         } finally {
             writeLock.unlock();


### PR DESCRIPTION
Replace all usages of the deprecated trafficAreaList() static method with the standard TrafficArea.values() enum method. Bump api-calls dependency from 3.3.2 to 4.1.0 for the Java 21 modernised version.

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
