### PR TITLE
fix: load Bedrock agent config from Secrets Manager

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <jvmMemory>4000</jvmMemory>
 
         <!-- DVSA Internal Libraries -->
-        <active-support.version>2.15.4</active-support.version>
+        <active-support.version>2.16.0</active-support.version>
         <api-calls.version>3.3.2</api-calls.version>
         <accessibility-ai.version>2.0.2</accessibility-ai.version>
 

--- a/src/test/java/org/dvsa/testing/framework/stepdefs/vol/TestRunConfiguration.java
+++ b/src/test/java/org/dvsa/testing/framework/stepdefs/vol/TestRunConfiguration.java
@@ -1,9 +1,11 @@
 package org.dvsa.testing.framework.stepdefs.vol;
 
+import activesupport.aws.s3.SecretsManager;
 import activesupport.driver.Browser;
 import io.cucumber.java.After;
 import io.cucumber.java.AfterAll;
 import io.cucumber.java.Before;
+import io.cucumber.java.BeforeAll;
 import io.cucumber.java.Scenario;
 import io.qameta.allure.Allure;
 import org.dvsa.testing.framework.Report.Config.Environments;
@@ -19,6 +21,22 @@ import static org.dvsa.testing.framework.pageObjects.BasePage.isLinkPresent;
 import static org.dvsa.testing.framework.pageObjects.BasePage.waitAndClick;
 
 public class TestRunConfiguration {
+
+    private static final String BEDROCK_SECRET = "vol-functional-tests/bedrock";
+
+    @BeforeAll
+    public static void loadBedrockConfig() {
+        try {
+            String agentId = SecretsManager.getSecretValue(BEDROCK_SECRET, "axe_agentId");
+            String aliasId = SecretsManager.getSecretValue(BEDROCK_SECRET, "axe_agentAliasId");
+            if (agentId != null) System.setProperty("bedrock.agent.id", agentId);
+            if (aliasId != null) System.setProperty("bedrock.agent.alias.id", aliasId);
+            System.out.println("Loaded Bedrock config from Secrets Manager");
+        } catch (Exception e) {
+            System.out.println("Could not load Bedrock config from Secrets Manager: " + e.getMessage());
+        }
+    }
+
     @Before
     public void setUp(Scenario scenario) throws Exception {
         Environments environments = new Environments();


### PR DESCRIPTION
Add @BeforeAll hook to fetch axe_agentId and axe_agentAliasId from vol-functional-tests/bedrock secret and set as system properties for the AI accessibility framework.

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
