### PR TITLE
feat: update last TM letter test to use new first-tm-letter batch job

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,8 @@
         <jvmMemory>4000</jvmMemory>
 
         <!-- DVSA Internal Libraries -->
-        <active-support.version>2.15.4</active-support.version>
+        <active-support.version>2.17.0</active-support.version>
         <api-calls.version>4.1.0</api-calls.version>
-        <active-support.version>2.16.0</active-support.version>
-        <api-calls.version>3.3.2</api-calls.version>
         <accessibility-ai.version>2.0.2</accessibility-ai.version>
 
         <!-- Testing Framework - Cucumber & JUnit -->

--- a/src/test/java/org/dvsa/testing/framework/enums/BatchCommands.java
+++ b/src/test/java/org/dvsa/testing/framework/enums/BatchCommands.java
@@ -3,6 +3,7 @@ package org.dvsa.testing.framework.enums;
 public enum BatchCommands {
     CONTINUATIONS_REMINDER("batch:digital-continuation-reminders"),
     LAST_TM_LETTER("batch:last-tm-letter"),
+    FIRST_TM_LETTER("batch:first-tm-letter"),
     DUPLICATE_VEHICLE_WARNING("batch:duplicate-vehicle-warning"),
     EXPIRE_BUS_REGISTRATION("batch:expire-bus-registration"),
     PROCESS_QUEUE("batch:process-queue"),

--- a/src/test/java/org/dvsa/testing/framework/stepdefs/vol/BatchProcess.java
+++ b/src/test/java/org/dvsa/testing/framework/stepdefs/vol/BatchProcess.java
@@ -43,6 +43,11 @@ public class BatchProcess extends BasePage {
         assertTrue(GenericUtils.jenkinsCLi(env, BatchCommands.DUPLICATE_VEHICLE_WARNING.toString(), SecretsManager.getSecretValue("jenkinsUser"), SecretsManager.getSecretValue("jenkinsAPIKey")));
     }
 
+    @And("the first TM letter job is run")
+    public void theFirstTMLetterJobIsRun() throws Exception {
+        assertTrue(awsBatch.triggerAwsBatchJob(JobDefinition.FIRST_TM_LETTER.name()));
+    }
+
     @And("the last TM letter job is run")
     public void theLastTMLetterJobIsRun() throws Exception {
         assertTrue(awsBatch.triggerAwsBatchJob(JobDefinition.LAST_TM_LETTER.name()));

--- a/src/test/java/org/dvsa/testing/framework/stepdefs/vol/RemoveTM.java
+++ b/src/test/java/org/dvsa/testing/framework/stepdefs/vol/RemoveTM.java
@@ -131,6 +131,6 @@ public class RemoveTM extends BasePage {
         sleep(20000);
         world.internalNavigation.navigateToPage("licence", SelfServeSection.VIEW);
         waitAndClickByLinkText("Docs & attachments");
-        assertTrue(isTextPresent("Last TM letter"));
+        assertTrue(isTextPresent("Last TM letter") || isTextPresent("1st letter"));
     }
 }

--- a/src/test/resources/org/dvsa/testing/framework/features/Internal/TM-Application/last-tm-letter.feature
+++ b/src/test/resources/org/dvsa/testing/framework/features/Internal/TM-Application/last-tm-letter.feature
@@ -12,5 +12,5 @@ Feature: Last TM letter sent
       When the licence has been granted
       And the internal user goes to remove the last transport manager
       And the user confirms a letter should be issued
-      Then the last TM letter job is run
+      Then the first TM letter job is run
       And the last TM letter should be sent

--- a/src/test/resources/org/dvsa/testing/framework/features/batch-jobs/batch-concurrent.feature
+++ b/src/test/resources/org/dvsa/testing/framework/features/batch-jobs/batch-concurrent.feature
@@ -3,6 +3,7 @@ Feature: AWS Batch - Concurrent Execution
 
   Scenario: Run all AWS batch jobs concurrently
     Given I submit the "LAST_TM_LETTER" batch job
+    And I submit the "FIRST_TM_LETTER" batch job
     And I submit the "CONTINUATIONS_REMINDER" batch job
     And I submit the "DUPLICATE_VEHICLE_WARNING" batch job
     And I submit the "EXPIRE_BUS_REGISTRATION" batch job


### PR DESCRIPTION
- Feature step now triggers batch:first-tm-letter instead of batch:last-tm-letter
- Added FIRST_TM_LETTER to BatchCommands enum
- Added new step definition for first TM letter job in BatchProcess
- Updated doc assertion to match new naming convention
- Added FIRST_TM_LETTER to batch-concurrent smoke test
- Bumped active-support to 2.17.0 for FIRST_TM_LETTER JobDefinition

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
