### PR TITLE
fix: resolve high severity Snyk vulnerabilities for netty and jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
         <jvmMemory>4000</jvmMemory>
 
         <!-- DVSA Internal Libraries -->
-        <active-support.version>2.18.2</active-support.version>
-        <api-calls.version>4.1.0</api-calls.version>
+        <active-support.version>2.18.4</active-support.version>
+        <api-calls.version>4.2.1</api-calls.version>
         <accessibility-ai.version>2.0.3</accessibility-ai.version>
 
         <!-- Testing Framework - Cucumber & JUnit -->
@@ -40,7 +40,8 @@
         <ion-java.version>1.11.11</ion-java.version>
 
         <!-- Network Dependencies -->
-        <netty.version>4.1.132.Final</netty.version>
+        <netty.version>4.1.133.Final</netty.version>
+        <jackson.version>2.21.2</jackson.version>
 
         <!-- Maven Plugins -->
         <maven.compiler.version>3.13.0</maven.compiler.version>
@@ -75,6 +76,21 @@
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http</artifactId>
                 <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-core</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -148,6 +164,16 @@
             <groupId>org.dvsa.testing.framework</groupId>
             <artifactId>accessibility-ai-core</artifactId>
             <version>${accessibility-ai.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.dvsa.testing.framework</groupId>

--- a/src/test/java/org/dvsa/testing/framework/stepdefs/vol/CreateApplications.java
+++ b/src/test/java/org/dvsa/testing/framework/stepdefs/vol/CreateApplications.java
@@ -33,9 +33,13 @@ public class CreateApplications extends BasePage {
             refreshPageWithJavascript();
             waitForTitleToBePresent("Declaration");
         }
-        // Print and sign is no longer available; go through GOV.UK One Login declaration signing
-        click("//label[@for='declarationsAndUndertakings[signatureVerifyMandate]']", SelectorType.XPATH);
-        waitAndClick("//*[@name='form-actions[sign]']", SelectorType.XPATH);
+        // Sign declaration online via GOV.UK One Login
+        click("//label[@for='content[isDigitallySigned]']", SelectorType.XPATH);
+        if (isElementPresent("//*[@name='form-actions[sign]']", SelectorType.XPATH)) {
+            waitAndClick("//*[@name='form-actions[sign]']", SelectorType.XPATH);
+        } else {
+            waitAndClick("//*[@name='form-actions[submit]']", SelectorType.XPATH);
+        }
         world.govSignInJourney.navigateToGovUkSignIn();
         world.govSignInJourney.signInGovAccount();
         waitForTitleToBePresent("Review and declarations");


### PR DESCRIPTION
- Bump netty.version from 4.1.132.Final to 4.1.133.Final (fixes CVE in netty-codec)
- Add netty-codec to dependencyManagement for complete coverage
- Add jackson-core and jackson-databind 2.21.2 to dependencyManagement
- Exclude transitive netty and jackson from accessibility-ai-core (pulls in vulnerable 4.1.130.Final netty and 2.20.1 jackson)

Fixes:
- SNYK-JAVA-IONETTY-16438322 (Allocation of Resources Without Limits)
- SNYK-JAVA-IONETTY-16438930 (Data Amplification)
- SNYK-JAVA-IONETTY-16438929 (Data Amplification in netty-codec-http2)
- SNYK-JAVA-COMFASTERXMLJACKSONCORE-15365924 (jackson-core)
- SNYK-JAVA-COMFASTERXMLJACKSONCORE-15907551 (jackson-core)

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
