### PR TITLE
feat: call submitVehicleSize() for PSV applications before granting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
         <!-- DVSA Internal Libraries -->
         <active-support.version>2.18.4</active-support.version>
-        <api-calls.version>4.2.1</api-calls.version>
+        <api-calls.version>4.3.0</api-calls.version>
         <accessibility-ai.version>2.0.3</accessibility-ai.version>
 
         <!-- Testing Framework - Cucumber & JUnit -->

--- a/src/test/java/org/dvsa/testing/framework/Journeys/licence/APIJourney.java
+++ b/src/test/java/org/dvsa/testing/framework/Journeys/licence/APIJourney.java
@@ -85,6 +85,9 @@ public class APIJourney {
             world.createApplication.addTmResponsibilities();
             world.createApplication.submitTmResponsibilities();
             world.createApplication.addVehicleDetails();
+            if (world.createApplication.getOperatorType().equals(OperatorType.PUBLIC.asString())) {
+                world.createApplication.submitVehicleSize();
+            }
             world.createApplication.addFinancialHistory();
             world.createApplication.addApplicationSafetyAndComplianceDetails();
             world.createApplication.addSafetyInspector();


### PR DESCRIPTION
VOL-5882 replaced the old vehicle-declaration/submit endpoint with PUT application/{id}/vehicle-size. Without this call, PSV apps have no vehicle size data and granting crashes in VehiclesSizeReviewService.

- Add submitVehicleSize() call in APIJourney.createApplication() for PSV apps
- Bump api-calls to 4.3.0 (contains the new submitVehicleSize method)

## Description

<!--
Include a summary of the change here.
-->

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
